### PR TITLE
links in issue description are  navigating to the pages

### DIFF
--- a/lib/src/pages/issues/issue_detail.dart
+++ b/lib/src/pages/issues/issue_detail.dart
@@ -1,3 +1,4 @@
+import 'package:blt/src/components/components_import.dart';
 import 'package:blt/src/pages/issues/issues_import.dart';
 import 'package:flutter/material.dart';
 
@@ -40,6 +41,17 @@ class IssueDetailPage extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    Future<void> _launchUrl(String link) async {
+      final uri = Uri.parse(link);
+      if (!await launchUrl(uri)) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text("Unable to launch the url."),
+          ),
+        );
+      }
+    }
+
     validScreenshotIndexes.clear();
     for (var i = 1; i <= issue.screenshotsLink!.length; i++) {
       validScreenshotIndexes.add(i);
@@ -163,6 +175,9 @@ class IssueDetailPage extends StatelessWidget {
                 data: replaceImageTags('${issue.description}'),
                 padding: EdgeInsets.all(0),
                 selectable: true,
+                onTapLink: (text, href, title) {
+                  _launchUrl(href!);
+                },
                 styleSheet: MarkdownStyleSheet.fromTheme(
                   ThemeData(
                     fontFamily: GoogleFonts.aBeeZee().fontFamily,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -25,7 +25,7 @@ dependencies:
   smooth_page_indicator: ^1.0.0+2
   pasteboard: ^0.2.0
   path_provider: ^2.0.13
-  url_launcher: ^6.1.10
+  url_launcher: ^6.2.5
   #flutter_inappwebview: ^5.7.2+3
   font_awesome_flutter: ^10.4.0
   sentry_flutter: ^7.2.0


### PR DESCRIPTION
## Issue
If one clicks on the provided link in the issue description it should take you to the required page but this feature was not there . With this pull request i have fixed #377 this issue and now it is working. 
<br>
<div style="display: flex">
<img src="https://github.com/OWASP-BLT/BLT-Flutter/assets/106571927/ab8e0bee-91bd-4d7a-ba00-3bd0d927789f" height=500px />
<img src="https://github.com/OWASP-BLT/BLT-Flutter/assets/106571927/402b8403-c8d9-4804-a8fe-60f4be9d552d" height=500px />
<img src="https://github.com/OWASP-BLT/BLT-Flutter/assets/106571927/381b5a70-c352-4590-bed7-78e3bfbd8509" height=500px />
</div>
