### PR TITLE
Fix RangeError in markdownNewLine Function for Text Insertion

### DIFF
--- a/lib/src/pages/home/report_bug.dart
+++ b/lib/src/pages/home/report_bug.dart
@@ -145,6 +145,9 @@ class _ReportFormState extends ConsumerState<ReportForm> {
     int end = _descriptionController.selection.extentOffset;
     String text = _descriptionController.text;
 
+    if (start < 0) start = 0;
+    if (end < 0) end = text.length;
+
     if (end < start) {
       int temp = start;
       start = end;


### PR DESCRIPTION
fixes #381 

This bug occurs if there is no selection or cursor position (both start and end are -1 initially) therefore putting a condition fixes this issue